### PR TITLE
Separate docker compose files, don't create network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 build: ## Build sphinx html at a certain path
-	docker compose run --build --rm -v $(path):/app builder	\
-	bash -c 'cd /app && rm -rf _build && make html SPHINXOPTS="-W --keep-going -n"'
+	docker compose -f docker-compose-builder.yaml run --build --rm -v $(path):/app builder	\
+	bash -c 'rm -rf _build && make html SPHINXOPTS="-W --keep-going -n"'
 
 serve: ## Serve html at a certain path
-	docker compose run --build --rm -it -p $(port):$(port) -v $(path):/app server \
-	/bin/sh -c "cd /app/_build/html && serve -n --no-port-switching -p $(port)"
+	docker compose -f docker-compose-server.yaml run --build --rm -p $(port):$(port) -v $(path):/app server \
+	/bin/sh -c "serve -n --no-port-switching -p $(port)"
 
 env: ## Set up the .env file, takes "spec" and "handbook" arguments representing the spec path and the handbook path
 	echo SPEC_PATH="$(spec)" > .env

--- a/docker-compose-builder.yaml
+++ b/docker-compose-builder.yaml
@@ -1,11 +1,7 @@
 services:
   builder:
     container_name: builder
+    network_mode: bridge
     image: builder
     build: ./docker/builder
-    working_dir: /app
-  server:
-    container_name: server
-    image: server
-    build: ./docker/server
     working_dir: /app

--- a/docker-compose-server.yaml
+++ b/docker-compose-server.yaml
@@ -1,0 +1,7 @@
+services:
+  server:
+    container_name: server
+    network_mode: bridge
+    image: server
+    build: ./docker/server
+    working_dir: /app/_build/html


### PR DESCRIPTION
- It doesn't make sense to have the `builder` and the `server` in the same docker-compose file.
- No need to create a new network, use the provided bridge network